### PR TITLE
Add managed-standard-storageclass

### DIFF
--- a/6-tfjob/src/managed-standard-storageclass.yaml
+++ b/6-tfjob/src/managed-standard-storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: managed-standard
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: Managed
+  storageaccounttype: Standard_LRS
+  cachingmode: ReadOnly


### PR DESCRIPTION
This yaml is needed for the managed-standard storage class that is currently missing in AKS. We need this for kfctl.sh so thought it made sense to keep it here so we can maintain it as part of this repo.