### PR TITLE
Shell script to create env variables in case of cloud shell timeout

### DIFF
--- a/2-kubernetes/README.md
+++ b/2-kubernetes/README.md
@@ -233,6 +233,34 @@ spec:
       restartPolicy: OnFailure # restart the pod if it fails
 ```
 
+For non-GPU clusters:
+```yaml
+apiVersion: batch/v1
+kind: Job # Our training should be a Job since it is supposed to terminate at some point
+metadata:
+  name: module2-ex1 # Name of our job
+spec:
+  template: # Template of the Pod that is going to be run by the Job
+    metadata:
+      name: module2-ex1 # Name of the pod
+    spec:
+      containers: # List of containers that should run inside the pod, in our case there is only one.
+        - name: tensorflow
+          image: ${DOCKER_USERNAME}/tf-mnist:cpu # The image to run, you can replace by your own.
+          args: ["--max_steps", "500"] # Optional arguments to pass to our command. By default the command is defined by ENTRYPOINT in the Dockerfile
+          resources:
+            limits:
+              nvidia.com/gpu: 1 # We ask Kubernetes to assign 1 GPU to this container
+          volumeMounts:
+            - name: nvidia
+              mountPath: /usr/local/nvidia
+      volumes:
+        - name: nvidia
+          hostPath:
+            path: /usr/local/nvidia
+      restartPolicy: OnFailure # restart the pod if it fails
+```
+
 Save this template somewhere and deploy it with:
 
 ```console

--- a/2-kubernetes/README.md
+++ b/2-kubernetes/README.md
@@ -248,9 +248,6 @@ spec:
         - name: tensorflow
           image: ${DOCKER_USERNAME}/tf-mnist:cpu # The image to run, you can replace by your own.
           args: ["--max_steps", "500"] # Optional arguments to pass to our command. By default the command is defined by ENTRYPOINT in the Dockerfile
-          resources:
-            limits:
-              nvidia.com/gpu: 1 # We ask Kubernetes to assign 1 GPU to this container
           volumeMounts:
             - name: nvidia
               mountPath: /usr/local/nvidia

--- a/4-kubeflow/README.md
+++ b/4-kubeflow/README.md
@@ -84,6 +84,16 @@ ${KUBEFLOW_SRC}/scripts/kfctl.sh apply k8s
 
 `kubectl get pods -n kubeflow`
 
+To make the kubeflow namespace the default for your context enter:
+```cli
+kubectl config get-contexts
+```
+Fine the name of you existing context which is the name of the cluster
+```cli
+kubectl config set-context aks-ejv --namespace kubeflow
+```
+Please use your own cluster name instread of aks-ejv
+
 should return something like this:
 
 ```

--- a/4-kubeflow/README.md
+++ b/4-kubeflow/README.md
@@ -31,6 +31,25 @@ Kubeflow uses [`ksonnet`](https://github.com/ksonnet/ksonnet) templates as a way
 
 First, install ksonnet version [0.13.1](https://ksonnet.io/#get-started), or you can [download a prebuilt binary](https://github.com/ksonnet/ksonnet/releases/tag/v0.13.1) for your OS.
 
+Pull down ksonnet in Cloud Shell
+
+```
+wget https://github.com/ksonnet/ksonnet/releases/download/v0.13.1/ks_0.13.1_linux_amd64.tar.gz
+```
+untar the zip
+
+```
+tar -zxvf ks_0.13.1_linux_amd64.tar.gz
+```
+
+Add the ksonnet cli to the CLoud Shell path
+
+```
+PATH=$PATH:~/ks_0.13.1_linux_amd64/
+```
+>NOTE: You may have to run this again if your cloud shell times out as it will not persist across sessions.
+
+
 Then run the following commands to download Kubeflow:
 
 ```bash

--- a/4-kubeflow/README.md
+++ b/4-kubeflow/README.md
@@ -129,7 +129,7 @@ kubeflow      workflow-controller-cf79dfbff-lv7jk                       1/1     
 
 The most important components for the purpose of this lab are `jupyter-0` which is the JupyterHub spawner running on your cluster, and `tf-job-operator-v1beta1-5949f668f7-j5zrn` which is a controller that will monitor your cluster for new TensorFlow training jobs (called `TfJobs`) specifications and manages the training, we will look at this two components later.
 
-### Remove Kubeflow
+### Remove Kubeflow _ONLY IF YOU ARE DONE WITH LABS!!!!
 
 If you want to remove the Kubeflow deployment, you can run the following to remove the namespace and installed components:
 

--- a/5-jupyterhub/README.md
+++ b/5-jupyterhub/README.md
@@ -68,10 +68,10 @@ Then navigate to JupyterHub: http://localhost:8080/hub
 To update the default service created for JupyterHub, run the following command to change the service to type LoadBalancer:
 
 ```bash
-cd ks_app
+cd kubeflow/mykubeflowapp/ks_app
 ks param set jupyter serviceType LoadBalancer
 cd ..
-${KUBEFLOW_SOURCE}/scripts/kfctl.sh apply k8s
+~/kubeflow/scripts/kfctl.sh apply k8s
 ```
 
 Create a new Jupyter Notebook instance:

--- a/5-jupyterhub/README.md
+++ b/5-jupyterhub/README.md
@@ -73,10 +73,14 @@ ks param set jupyter serviceType LoadBalancer
 cd ..
 ~/kubeflow/scripts/kfctl.sh apply k8s
 ```
+wait for the public IP of the jupyter service
+```
+kubectl get svc -w
+```
 
 Create a new Jupyter Notebook instance:
 
-- open http://localhost:8080/hub/ in your browser (or use the public IP for the service `tf-hub-lb`)
+- open http://<PublicIP_OF_JUPYTER_SVC>/hub/ in your browser (or use the public IP for the service `tf-hub-lb`)
 - log in using any username and password
 - click the "Start My Server" button to sprawn a new Jupyter notebook
 - from the image dropdown, select a tensorflow image for your notebook

--- a/6-tfjob/README.md
+++ b/6-tfjob/README.md
@@ -102,6 +102,24 @@ spec:
           restartPolicy: OnFailure
 ```
 
+For Non-GPU clusters:
+```yaml
+apiVersion: kubeflow.org/v1beta1
+kind: TFJob
+metadata:
+  name: module6-ex1
+spec:
+  tfReplicaSpecs:
+    MASTER:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - image: <DOCKER_USERNAME>/tf-mnist # From module 1
+              name: tensorflow
+          restartPolicy: OnFailure
+```
+
 Save the template that applies to you in a file, and create the `TFJob`:
 
 ```console
@@ -219,6 +237,22 @@ Turns out mounting an Azure File share into a container is really easy, we simpl
       claimName: azurefile
 ```
 
+For non-GPU Clusters:
+```yaml
+[...]
+ containers:
+  - image: <IMAGE>
+    name: tensorflow
+    volumeMounts:
+      - name: azurefile
+        subPath: module6-ex2
+        mountPath: /tmp/tensorflow
+ volumes:
+  - name: azurefile
+    persistentVolumeClaim:
+      claimName: azurefile
+```
+
 Update your template from exercise 1 to mount the Azure File share into your container, and create your new job.
 
 Once the container starts running, if you go to the Azure Portal, into your storage account, and browse your `tensorflow` file share, you should see something like that:
@@ -264,6 +298,38 @@ spec:
               persistentVolumeClaim:
                 claimName: azurefile
 ```
+
+For non-GPU cluster:
+```yaml
+apiVersion: kubeflow.org/v1beta1
+kind: TFJob
+metadata:
+  name: module6-ex2
+spec:
+  tfReplicaSpecs:
+    MASTER:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - image: <DOCKER_USERNAME>/tf-mnist
+              name: tensorflow
+              volumeMounts:
+                # By default our classifier saves the summaries in /tmp/tensorflow,
+                # so that's where we want to mount our Azure File Share.
+                - name: azurefile
+                  # The subPath allows us to mount a subdirectory within the azure file share instead of root
+                  # this is useful so that we can save the logs for each run in a different subdirectory
+                  # instead of overwriting what was done before.
+                  subPath: module6-ex2
+                  mountPath: /tmp/tensorflow
+          restartPolicy: OnFailure
+          volumes:
+            - name: azurefile
+              persistentVolumeClaim:
+                claimName: azurefile
+```
+
 
 </details>
 

--- a/6-tfjob/README.md
+++ b/6-tfjob/README.md
@@ -115,7 +115,7 @@ spec:
       template:
         spec:
           containers:
-            - image: <DOCKER_USERNAME>/tf-mnist # From module 1
+            - image: <DOCKER_USERNAME>/tf-mnist:cpu # From module 1
               name: tensorflow
           restartPolicy: OnFailure
 ```

--- a/6-tfjob/README.md
+++ b/6-tfjob/README.md
@@ -384,7 +384,7 @@ spec:
       template:
         spec:
           containers:
-            - image: <DOCKER_USERNAME>/tf-mnist
+            - image: <DOCKER_USERNAME>/tf-mnist:cpu
               name: tensorflow
               volumeMounts:
                 # By default our classifier saves the summaries in /tmp/tensorflow,

--- a/6-tfjob/README.md
+++ b/6-tfjob/README.md
@@ -227,7 +227,7 @@ subjects:
   namespace: kube-system
 ```
 
-apply the rabc files
+apply the rbac files
 ```cli
 kubectl apply -f azurefiles-rbac.yaml
 ```
@@ -270,7 +270,7 @@ spec:
 
 Apply the pvc file to the cluster
 ```cli
-kubectl apply azurefiles-class.yaml
+kubectl apply -f azurefiles-pvc.yaml
 ```
 
 Once you completed all the steps, run:

--- a/6-tfjob/README.md
+++ b/6-tfjob/README.md
@@ -201,7 +201,7 @@ Be aware of a few details first:
 - PVC are namespaced so be sure to create it on the same namespace that is launching the TFJob objects
 - If you are using RBAC might need to run the cluster role and binding: [see docs here](https://docs.microsoft.com/en-us/azure/aks/azure-files-dynamic-pv#create-a-cluster-role-and-binding)
 
-Create an `azuefiles-rbac.yaml` file
+Create an `azurefiles-rbac.yaml` file
 ```yaml
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/8-hyperparam-sweep/README.md
+++ b/8-hyperparam-sweep/README.md
@@ -79,50 +79,6 @@ This chart should also deploy a single TensorBoard instance (and it's associated
 
 If you are pretty new to Kubernetes and Helm and don't feel like building your own helm chart just yet, you can skip to the solution where details and explanations are provided.
 
-#### Validation
-
-Once you have created and deployed your chart, looking at the pods that were created, you should see a bunch of them, as well as a single TensorBoard instance monitoring all of them:
-
-```console
-kubectl get pods
-```
-
-```
-NAME                                      READY     STATUS    RESTARTS   AGE
-module8-tensorboard-7ccb598cdd-6vg7h       1/1       Running   0          16s
-module8-tf-paint-0-0-master-juc5-0-hw5cm   0/1       Pending   0          4s
-module8-tf-paint-0-1-master-pu49-0-jp06r   1/1       Running   0          14s
-module8-tf-paint-0-2-master-awhs-0-gfra0   0/1       Pending   0          6s
-module8-tf-paint-1-0-master-5tfm-0-dhhhv   1/1       Running   0          16s
-module8-tf-paint-1-1-master-be91-0-zw4gk   1/1       Running   0          16s
-module8-tf-paint-1-2-master-r2nd-0-zhws1   0/1       Pending   0          7s
-module8-tf-paint-2-0-master-7w37-0-ff0w9   0/1       Pending   0          13s
-module8-tf-paint-2-1-master-260j-0-l4o7r   0/1       Pending   0          10s
-module8-tf-paint-2-2-master-jtjb-0-5l84q   0/1       Pending   0          9s
-```
-Note: Some pods are pending due to the GPU resource available in the cluster. If you have 3 GPUs in the cluster, then there can only be a maximum number of 3 parallel trainings at a given time.
-
-Once the TensorBoard service for this module is created, you can use the External-IP of that service to connect to the TensorBoard.
-
-```console
-kubectl get service
-
-NAME                                 TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)             AGE
-module8-tensorboard                  LoadBalancer   10.0.142.217   <PUBLIC IP>     80:30896/TCP        5m
-
-```
-
-Looking at TensorBoard, you should see something similar to this:
-![TensorBoard](tensorboard.png)
-
-> Note that TensorBoard can take a while before correctly displaying images.
-
-Here we can see that some models are doing much better than others. Models with a learning rate of `0.1` for example are producing an all-black image, we are probably over-shooting.  
-After a few minutes, we can see that the two best performing models are:
-* 5 hidden layers and learning rate of `0.01`
-* 7 hidden layers and learning rate of `0.001`
-
-At this point we could decide to kill all the other models if we wanted to free some capacity in our cluster, or launch additional new experiments based on our initial findings.
 
 #### Exercise 1
 git clone this repo
@@ -173,7 +129,50 @@ module8-tensorboard-7ccb598cdd-6vg7h   0/1    ContainerCreating  0         1s
 
 ```
 </details>
+#### Validation
 
+Once you have created and deployed your chart, looking at the pods that were created, you should see a bunch of them, as well as a single TensorBoard instance monitoring all of them:
+
+```console
+kubectl get pods
+```
+
+```
+NAME                                      READY     STATUS    RESTARTS   AGE
+module8-tensorboard-7ccb598cdd-6vg7h       1/1       Running   0          16s
+module8-tf-paint-0-0-master-juc5-0-hw5cm   0/1       Pending   0          4s
+module8-tf-paint-0-1-master-pu49-0-jp06r   1/1       Running   0          14s
+module8-tf-paint-0-2-master-awhs-0-gfra0   0/1       Pending   0          6s
+module8-tf-paint-1-0-master-5tfm-0-dhhhv   1/1       Running   0          16s
+module8-tf-paint-1-1-master-be91-0-zw4gk   1/1       Running   0          16s
+module8-tf-paint-1-2-master-r2nd-0-zhws1   0/1       Pending   0          7s
+module8-tf-paint-2-0-master-7w37-0-ff0w9   0/1       Pending   0          13s
+module8-tf-paint-2-1-master-260j-0-l4o7r   0/1       Pending   0          10s
+module8-tf-paint-2-2-master-jtjb-0-5l84q   0/1       Pending   0          9s
+```
+Note: Some pods are pending due to the GPU resource available in the cluster. If you have 3 GPUs in the cluster, then there can only be a maximum number of 3 parallel trainings at a given time.
+
+Once the TensorBoard service for this module is created, you can use the External-IP of that service to connect to the TensorBoard.
+
+```console
+kubectl get service
+
+NAME                                 TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)             AGE
+module8-tensorboard                  LoadBalancer   10.0.142.217   <PUBLIC IP>     80:30896/TCP        5m
+
+```
+
+Looking at TensorBoard, you should see something similar to this:
+![TensorBoard](tensorboard.png)
+
+> Note that TensorBoard can take a while before correctly displaying images.
+
+Here we can see that some models are doing much better than others. Models with a learning rate of `0.1` for example are producing an all-black image, we are probably over-shooting.  
+After a few minutes, we can see that the two best performing models are:
+* 5 hidden layers and learning rate of `0.01`
+* 7 hidden layers and learning rate of `0.001`
+
+At this point we could decide to kill all the other models if we wanted to free some capacity in our cluster, or launch additional new experiments based on our initial findings.
 ## Next Step
 
 [9 - Serving](../9-serving)

--- a/8-hyperparam-sweep/README.md
+++ b/8-hyperparam-sweep/README.md
@@ -124,11 +124,11 @@ After a few minutes, we can see that the two best performing models are:
 
 At this point we could decide to kill all the other models if we wanted to free some capacity in our cluster, or launch additional new experiments based on our initial findings.
 
-#### Solution
+#### Exercise 1
 git clone this repo
 ```
 git clone https://github.com/evillgenius75/kubeflow-labs.git
-cd kubeflow-lab
+cd kubeflow-labs
 ```
 
 Check out the commented solution chart: [./solution-chart/templates/deployment.yaml](./solution-chart/templates/deployment.yaml)

--- a/8-hyperparam-sweep/README.md
+++ b/8-hyperparam-sweep/README.md
@@ -88,7 +88,6 @@ cd kubeflow-labs
 ```
 
 Check out the commented solution chart: [./solution-chart/templates/deployment.yaml](./solution-chart/templates/deployment.yaml)
-<details>
 <summary><strong>Hyperparameter Sweep Helm Chart</strong></summary>
 
 Install the chart with command:
@@ -128,7 +127,7 @@ NAME                                  READY  STATUS             RESTARTS  AGE
 module8-tensorboard-7ccb598cdd-6vg7h   0/1    ContainerCreating  0         1s
 
 ```
-</details>
+
 #### Validation
 
 Once you have created and deployed your chart, looking at the pods that were created, you should see a bunch of them, as well as a single TensorBoard instance monitoring all of them:

--- a/8-hyperparam-sweep/README.md
+++ b/8-hyperparam-sweep/README.md
@@ -51,7 +51,7 @@ hyperParamValues:
     - 6
     - 7
 ```
-
+Let's 
 That way, when installing the chart, 9 `TFJob` will actually get deployed, testing all the combination of learning rate and hidden layers depth that we specified.
 This is a very simple example (our model is also very simple), but hopefully you start to see the possibilities than Helm offers.
 
@@ -125,6 +125,12 @@ After a few minutes, we can see that the two best performing models are:
 At this point we could decide to kill all the other models if we wanted to free some capacity in our cluster, or launch additional new experiments based on our initial findings.
 
 #### Solution
+git clone this repo
+```
+git clone https://github.com/evillgenius75/kubeflow-labs.git
+cd kubeflow-lab
+```
+
 Check out the commented solution chart: [./solution-chart/templates/deployment.yaml](./solution-chart/templates/deployment.yaml)
 <details>
 <summary><strong>Hyperparameter Sweep Helm Chart</strong></summary>
@@ -133,7 +139,7 @@ Install the chart with command:
 
 ```console
 cd 8-hyperparam-sweep/solution-chart/
-helm install .
+helm install . -f values-cpu.yaml
 
 NAME:   telling-buffalo
 LAST DEPLOYED: 

--- a/8-hyperparam-sweep/solution-chart/values-cpu.yaml
+++ b/8-hyperparam-sweep/solution-chart/values-cpu.yaml
@@ -1,0 +1,1 @@
+image: ritazh/paint:cpu

--- a/8-hyperparam-sweep/solution-chart/values-cpu.yaml
+++ b/8-hyperparam-sweep/solution-chart/values-cpu.yaml
@@ -1,1 +1,11 @@
-image: ritazh/paint:cpu
+image: ritazh/tf-paint:cpu
+useGPU: false
+hyperParamValues:
+  learningRate:
+    - 0.001
+    - 0.01
+    - 0.1
+  hiddenLayers:
+    - 5
+    - 6
+    - 7


### PR DESCRIPTION
Create a shell script to generate environment variables in case of cloud shell timeout
1. Create `env.sh` file under `~`
```
nano ~/env.sh
```

2. Copy & paste below and save
```sh
#!bin/bash
export PATH="$PATH:~/ks_0.13.1_linux_amd64/"
echo "PATH=$PATH"
export KUBEFLOW_SRC=$(realpath kubeflow)
echo "KUBEFLOW_SRC=$KUBEFLOW_SRC"
export KUBEFLOW_TAG=v0.4.1
echo "KUBEFLOW_TAG=$KUBEFLOW_TAG"
export KFAPP=mykubeflowapp
echo "KFAPP=$KFAPP"
```

3. Change permission to executable
```sh
chmod +x ~/env.sh
```

4. Run below to set the variables in case of cloud shell timeout
```sh
source ~/env.sh
```
